### PR TITLE
Add bottom-right hand-gesture scroll zone to trigger page scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
             <li><a href="#stats">Stats</a></li>
             <li><a href="#career">Career</a></li>
             <li><a href="#gallery">Gallery</a></li>
+            <li><a href="#videos">Videos</a></li>
             <li><a href="#nicknames">Nicknames</a></li>
             <li><a href="#quotes">Quotes</a></li>
             <li><a href="#performance">Seasons</a></li>
@@ -306,6 +307,53 @@
         </div>
     </section>
 
+
+    <!-- Videos Section -->
+    <section class="section videos-section" id="videos">
+        <div class="container">
+            <h2 class="section-title">Watch Max in Action</h2>
+            <p class="chart-subtitle">경기 하이라이트와 팀 라디오를 바로 재생해보세요.</p>
+            <div class="videos-grid">
+                <article class="video-card reveal">
+                    <div class="video-frame">
+                        <iframe
+                            src="https://www.youtube.com/embed/7QJ-N-AQJYc"
+                            title="Max Verstappen 2023 World Champion Moments"
+                            loading="lazy"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            referrerpolicy="strict-origin-when-cross-origin"
+                            allowfullscreen></iframe>
+                    </div>
+                    <h3>World Champion Highlights</h3>
+                </article>
+                <article class="video-card reveal">
+                    <div class="video-frame">
+                        <iframe
+                            src="https://www.youtube.com/embed/Vx2fNfdrx4M"
+                            title="Best of Max Verstappen Team Radio"
+                            loading="lazy"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            referrerpolicy="strict-origin-when-cross-origin"
+                            allowfullscreen></iframe>
+                    </div>
+                    <h3>Best Team Radio Moments</h3>
+                </article>
+                <article class="video-card reveal">
+                    <div class="video-frame">
+                        <iframe
+                            src="https://www.youtube.com/embed/C5d8C9fJ8xU"
+                            title="Max Verstappen Overtake Compilation"
+                            loading="lazy"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            referrerpolicy="strict-origin-when-cross-origin"
+                            allowfullscreen></iframe>
+                    </div>
+                    <h3>Overtake Compilation</h3>
+                </article>
+            </div>
+        </div>
+    </section>
+
     <!-- Nicknames Word Cloud Section -->
     <section class="section nicknames-section" id="nicknames">
         <div class="container">
@@ -544,7 +592,6 @@
     <video id="gesture-video" playsinline muted></video>
     <button id="gesture-toggle"><span class="gesture-icon">✋</span> 손 제스처</button>
     <div id="gesture-status"></div>
-    <div id="gesture-scroll-zone">👇 SCROLL ZONE</div>
 
     <script src="script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             <li><a href="#stats">Stats</a></li>
             <li><a href="#career">Career</a></li>
             <li><a href="#gallery">Gallery</a></li>
-            <li><a href="#instagram">Instagram</a></li>
+            <li><a href="#merch">Merch</a></li>
             <li><a href="#nicknames">Nicknames</a></li>
             <li><a href="#quotes">Quotes</a></li>
             <li><a href="#performance">Seasons</a></li>
@@ -308,24 +308,32 @@
     </section>
 
 
-    <!-- Instagram Section -->
-    <section class="section instagram-section" id="instagram">
+    <!-- Merch Section -->
+    <section class="section merch-section" id="merch">
         <div class="container">
-            <h2 class="section-title">Instagram Official Posts</h2>
-            <p class="chart-subtitle">@maxverstappen1 공식 게시물을 홈페이지에서 바로 확인하세요.</p>
-            <div class="instagram-grid">
-                <article class="instagram-card reveal">
-                    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/C6f0J4TMD2m/" data-instgrm-version="14"></blockquote>
-                    <a class="insta-link" href="https://www.instagram.com/p/C6f0J4TMD2m/" target="_blank" rel="noopener noreferrer">Instagram에서 열기 ↗</a>
-                </article>
-                <article class="instagram-card reveal">
-                    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/C9P4z7OMn5F/" data-instgrm-version="14"></blockquote>
-                    <a class="insta-link" href="https://www.instagram.com/p/C9P4z7OMn5F/" target="_blank" rel="noopener noreferrer">Instagram에서 열기 ↗</a>
-                </article>
-                <article class="instagram-card reveal">
-                    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/DA5PgmjMo5S/" data-instgrm-version="14"></blockquote>
-                    <a class="insta-link" href="https://www.instagram.com/p/DA5PgmjMo5S/" target="_blank" rel="noopener noreferrer">Instagram에서 열기 ↗</a>
-                </article>
+            <h2 class="section-title">Official Merch Stores</h2>
+            <p class="chart-subtitle">공식 굿즈 스토어로 바로 이동해 원하는 상품을 확인해보세요.</p>
+            <div class="merch-grid">
+                <a class="merch-card reveal" href="https://store.verstappen.com/en/" target="_blank" rel="noopener noreferrer">
+                    <h3>Verstappen Official Store</h3>
+                    <p>막스 베르스타펜 공식 스토어</p>
+                    <span>사이트 열기 ↗</span>
+                </a>
+                <a class="merch-card reveal" href="https://www.redbullshopus.com/" target="_blank" rel="noopener noreferrer">
+                    <h3>Red Bull Shop US</h3>
+                    <p>Red Bull Racing 공식 팀 굿즈</p>
+                    <span>사이트 열기 ↗</span>
+                </a>
+                <a class="merch-card reveal" href="https://www.fuelforfans.com/global/en/home/" target="_blank" rel="noopener noreferrer">
+                    <h3>Fuel For Fans</h3>
+                    <p>모터스포츠 브랜드 공식 머천다이즈</p>
+                    <span>사이트 열기 ↗</span>
+                </a>
+                <a class="merch-card reveal" href="https://f1store.formula1.com/en/" target="_blank" rel="noopener noreferrer">
+                    <h3>F1 Official Store</h3>
+                    <p>포뮬러1 공식 스토어</p>
+                    <span>사이트 열기 ↗</span>
+                </a>
             </div>
         </div>
     </section>
@@ -569,7 +577,6 @@
     <button id="gesture-toggle"><span class="gesture-icon">✋</span> 손 제스처</button>
     <div id="gesture-status"></div>
 
-    <script async src="https://www.instagram.com/embed.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             <li><a href="#stats">Stats</a></li>
             <li><a href="#career">Career</a></li>
             <li><a href="#gallery">Gallery</a></li>
-            <li><a href="#videos">Videos</a></li>
+            <li><a href="#instagram">Instagram</a></li>
             <li><a href="#nicknames">Nicknames</a></li>
             <li><a href="#quotes">Quotes</a></li>
             <li><a href="#performance">Seasons</a></li>
@@ -308,53 +308,23 @@
     </section>
 
 
-    <!-- Videos Section -->
-    <section class="section videos-section" id="videos">
+    <!-- Instagram Section -->
+    <section class="section instagram-section" id="instagram">
         <div class="container">
-            <h2 class="section-title">Watch Max in Action</h2>
-            <p class="chart-subtitle">경기 하이라이트와 팀 라디오를 바로 재생해보세요.</p>
-            <div class="videos-grid">
-                <article class="video-card reveal">
-                    <div class="video-frame">
-                        <iframe
-                            src="https://www.youtube-nocookie.com/embed/z8Ad-8B7fGQ?rel=0&modestbranding=1&playsinline=1"
-                            title="Max Verstappen 2023 Brazil Grand Prix Highlights"
-                            loading="lazy"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                            referrerpolicy="strict-origin-when-cross-origin"
-                            allowfullscreen></iframe>
-                    </div>
-                    <h3>Grand Prix Highlights</h3>
-                    <p class="video-note">임베드 재생이 막히면 아래 버튼으로 유튜브에서 바로 열 수 있어요.</p>
-                    <a class="video-link" href="https://www.youtube.com/watch?v=z8Ad-8B7fGQ" target="_blank" rel="noopener noreferrer">YouTube에서 보기 ↗</a>
+            <h2 class="section-title">Instagram Official Posts</h2>
+            <p class="chart-subtitle">@maxverstappen1 공식 게시물을 홈페이지에서 바로 확인하세요.</p>
+            <div class="instagram-grid">
+                <article class="instagram-card reveal">
+                    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/C6f0J4TMD2m/" data-instgrm-version="14"></blockquote>
+                    <a class="insta-link" href="https://www.instagram.com/p/C6f0J4TMD2m/" target="_blank" rel="noopener noreferrer">Instagram에서 열기 ↗</a>
                 </article>
-                <article class="video-card reveal">
-                    <div class="video-frame">
-                        <iframe
-                            src="https://www.youtube-nocookie.com/embed/NxP5S8x6q8I?rel=0&modestbranding=1&playsinline=1"
-                            title="Max Verstappen Team Radio Highlights"
-                            loading="lazy"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                            referrerpolicy="strict-origin-when-cross-origin"
-                            allowfullscreen></iframe>
-                    </div>
-                    <h3>Best Team Radio Moments</h3>
-                    <p class="video-note">사내/학교 네트워크 정책으로 재생이 차단될 수도 있습니다.</p>
-                    <a class="video-link" href="https://www.youtube.com/watch?v=NxP5S8x6q8I" target="_blank" rel="noopener noreferrer">YouTube에서 보기 ↗</a>
+                <article class="instagram-card reveal">
+                    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/C9P4z7OMn5F/" data-instgrm-version="14"></blockquote>
+                    <a class="insta-link" href="https://www.instagram.com/p/C9P4z7OMn5F/" target="_blank" rel="noopener noreferrer">Instagram에서 열기 ↗</a>
                 </article>
-                <article class="video-card reveal">
-                    <div class="video-frame">
-                        <iframe
-                            src="https://www.youtube-nocookie.com/embed/7R4l8QvN0R8?rel=0&modestbranding=1&playsinline=1"
-                            title="Max Verstappen Overtake Highlights"
-                            loading="lazy"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                            referrerpolicy="strict-origin-when-cross-origin"
-                            allowfullscreen></iframe>
-                    </div>
-                    <h3>Overtake Compilation</h3>
-                    <p class="video-note">임베드 제한 영상은 플레이어 대신 링크 이동으로 시청 가능합니다.</p>
-                    <a class="video-link" href="https://www.youtube.com/watch?v=7R4l8QvN0R8" target="_blank" rel="noopener noreferrer">YouTube에서 보기 ↗</a>
+                <article class="instagram-card reveal">
+                    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/DA5PgmjMo5S/" data-instgrm-version="14"></blockquote>
+                    <a class="insta-link" href="https://www.instagram.com/p/DA5PgmjMo5S/" target="_blank" rel="noopener noreferrer">Instagram에서 열기 ↗</a>
                 </article>
             </div>
         </div>
@@ -599,6 +569,7 @@
     <button id="gesture-toggle"><span class="gesture-icon">✋</span> 손 제스처</button>
     <div id="gesture-status"></div>
 
+    <script async src="https://www.instagram.com/embed.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -317,38 +317,44 @@
                 <article class="video-card reveal">
                     <div class="video-frame">
                         <iframe
-                            src="https://www.youtube.com/embed/7QJ-N-AQJYc"
-                            title="Max Verstappen 2023 World Champion Moments"
+                            src="https://www.youtube-nocookie.com/embed/z8Ad-8B7fGQ?rel=0&modestbranding=1&playsinline=1"
+                            title="Max Verstappen 2023 Brazil Grand Prix Highlights"
                             loading="lazy"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             referrerpolicy="strict-origin-when-cross-origin"
                             allowfullscreen></iframe>
                     </div>
-                    <h3>World Champion Highlights</h3>
+                    <h3>Grand Prix Highlights</h3>
+                    <p class="video-note">임베드 재생이 막히면 아래 버튼으로 유튜브에서 바로 열 수 있어요.</p>
+                    <a class="video-link" href="https://www.youtube.com/watch?v=z8Ad-8B7fGQ" target="_blank" rel="noopener noreferrer">YouTube에서 보기 ↗</a>
                 </article>
                 <article class="video-card reveal">
                     <div class="video-frame">
                         <iframe
-                            src="https://www.youtube.com/embed/Vx2fNfdrx4M"
-                            title="Best of Max Verstappen Team Radio"
+                            src="https://www.youtube-nocookie.com/embed/NxP5S8x6q8I?rel=0&modestbranding=1&playsinline=1"
+                            title="Max Verstappen Team Radio Highlights"
                             loading="lazy"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             referrerpolicy="strict-origin-when-cross-origin"
                             allowfullscreen></iframe>
                     </div>
                     <h3>Best Team Radio Moments</h3>
+                    <p class="video-note">사내/학교 네트워크 정책으로 재생이 차단될 수도 있습니다.</p>
+                    <a class="video-link" href="https://www.youtube.com/watch?v=NxP5S8x6q8I" target="_blank" rel="noopener noreferrer">YouTube에서 보기 ↗</a>
                 </article>
                 <article class="video-card reveal">
                     <div class="video-frame">
                         <iframe
-                            src="https://www.youtube.com/embed/C5d8C9fJ8xU"
-                            title="Max Verstappen Overtake Compilation"
+                            src="https://www.youtube-nocookie.com/embed/7R4l8QvN0R8?rel=0&modestbranding=1&playsinline=1"
+                            title="Max Verstappen Overtake Highlights"
                             loading="lazy"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             referrerpolicy="strict-origin-when-cross-origin"
                             allowfullscreen></iframe>
                     </div>
                     <h3>Overtake Compilation</h3>
+                    <p class="video-note">임베드 제한 영상은 플레이어 대신 링크 이동으로 시청 가능합니다.</p>
+                    <a class="video-link" href="https://www.youtube.com/watch?v=7R4l8QvN0R8" target="_blank" rel="noopener noreferrer">YouTube에서 보기 ↗</a>
                 </article>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -544,6 +544,7 @@
     <video id="gesture-video" playsinline muted></video>
     <button id="gesture-toggle"><span class="gesture-icon">✋</span> 손 제스처</button>
     <div id="gesture-status"></div>
+    <div id="gesture-scroll-zone">👇 SCROLL ZONE</div>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -269,7 +269,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const video       = document.getElementById('gesture-video');
     const toggleBtn   = document.getElementById('gesture-toggle');
     const statusEl    = document.getElementById('gesture-status');
-    const scrollZoneEl = document.getElementById('gesture-scroll-zone');
 
     if (!handCanvas || !video || !toggleBtn) return;
 
@@ -306,48 +305,6 @@ document.addEventListener('DOMContentLoaded', () => {
     let prevPinchX     = 0;
     let prevPinchY     = 0;
     let processingFrame = false;
-    let pinchHoldFrames = 0;
-    let lastScrollAt = 0;
-    let zoneActive = false;
-
-
-    function updateScrollZoneUI(active) {
-        if (!scrollZoneEl) return;
-        zoneActive = active;
-        scrollZoneEl.classList.toggle('active', active);
-    }
-
-    function pointInScrollZone(x, y) {
-        if (!scrollZoneEl) return false;
-        const zoneRect = scrollZoneEl.getBoundingClientRect();
-        return x >= zoneRect.left && x <= zoneRect.right && y >= zoneRect.top && y <= zoneRect.bottom;
-    }
-
-    function handleGestureScroll(x, y, pinchNow, dist) {
-        if (!gestureActive || !pinchNow) {
-            pinchHoldFrames = 0;
-            updateScrollZoneUI(false);
-            return;
-        }
-
-        const inZone = pointInScrollZone(x, y);
-        updateScrollZoneUI(inZone);
-
-        if (!inZone) {
-            pinchHoldFrames = 0;
-            return;
-        }
-
-        pinchHoldFrames += 1;
-        const now = performance.now();
-        const isStrongPinch = dist < PINCH_THRESHOLD * 0.82;
-
-        if (pinchHoldFrames >= 3 && (isStrongPinch || now - lastScrollAt > 360)) {
-            window.scrollBy({ top: 130, behavior: 'smooth' });
-            lastScrollAt = now;
-            pinchHoldFrames = 1;
-        }
-    }
 
     // --- Physics loop (always running, acts only on flying words) ---
     function physicsLoop() {
@@ -508,8 +465,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (!results.multiHandLandmarks || results.multiHandLandmarks.length === 0) {
             if (isPinching) { isPinching = false; releaseWord(); }
-            pinchHoldFrames = 0;
-            updateScrollZoneUI(false);
             return;
         }
 
@@ -531,7 +486,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const sy    = midNY       * window.innerHeight;
 
         drawPinchIndicator(sx, sy, pinchNow, dist);
-        handleGestureScroll(sx, sy, pinchNow, dist);
 
         if (pinchNow && !isPinching) {
             // Pinch start
@@ -639,7 +593,7 @@ document.addEventListener('DOMContentLoaded', () => {
         try { await handsInstance.send({ image: video }); } catch (_) {}
 
         mediapipeReady = true;
-        setStatus('✋ 집기/던지기 + 우하단 SCROLL ZONE에서 스크롤');
+        setStatus('✋ 엄지+검지로 별명을 집어 던지세요!');
 
         // Frame processing loop
         async function processFrame() {
@@ -669,12 +623,11 @@ document.addEventListener('DOMContentLoaded', () => {
             handCanvas.style.display = 'block';
             video.style.display      = 'block';
             statusEl.style.display   = 'block';
-            if (scrollZoneEl) scrollZoneEl.style.display = 'flex';
 
             if (!mediapipeReady) {
                 await initHandTracking();
             } else {
-                setStatus('✋ 집기/던지기 + 우하단 SCROLL ZONE에서 스크롤');
+                setStatus('✋ 엄지+검지로 별명을 집어 던지세요!');
                 // Restart frame loop
                 async function processFrame() {
                     if (!gestureActive) return;
@@ -693,9 +646,6 @@ document.addEventListener('DOMContentLoaded', () => {
             handCanvas.style.display = 'none';
             video.style.display      = 'none';
             statusEl.style.display   = 'none';
-            if (scrollZoneEl) scrollZoneEl.style.display = 'none';
-            pinchHoldFrames = 0;
-            updateScrollZoneUI(false);
 
             hCtx.clearRect(0, 0, handCanvas.width, handCanvas.height);
             if (isPinching) { isPinching = false; releaseWord(); }

--- a/script.js
+++ b/script.js
@@ -269,6 +269,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const video       = document.getElementById('gesture-video');
     const toggleBtn   = document.getElementById('gesture-toggle');
     const statusEl    = document.getElementById('gesture-status');
+    const scrollZoneEl = document.getElementById('gesture-scroll-zone');
 
     if (!handCanvas || !video || !toggleBtn) return;
 
@@ -305,6 +306,48 @@ document.addEventListener('DOMContentLoaded', () => {
     let prevPinchX     = 0;
     let prevPinchY     = 0;
     let processingFrame = false;
+    let pinchHoldFrames = 0;
+    let lastScrollAt = 0;
+    let zoneActive = false;
+
+
+    function updateScrollZoneUI(active) {
+        if (!scrollZoneEl) return;
+        zoneActive = active;
+        scrollZoneEl.classList.toggle('active', active);
+    }
+
+    function pointInScrollZone(x, y) {
+        if (!scrollZoneEl) return false;
+        const zoneRect = scrollZoneEl.getBoundingClientRect();
+        return x >= zoneRect.left && x <= zoneRect.right && y >= zoneRect.top && y <= zoneRect.bottom;
+    }
+
+    function handleGestureScroll(x, y, pinchNow, dist) {
+        if (!gestureActive || !pinchNow) {
+            pinchHoldFrames = 0;
+            updateScrollZoneUI(false);
+            return;
+        }
+
+        const inZone = pointInScrollZone(x, y);
+        updateScrollZoneUI(inZone);
+
+        if (!inZone) {
+            pinchHoldFrames = 0;
+            return;
+        }
+
+        pinchHoldFrames += 1;
+        const now = performance.now();
+        const isStrongPinch = dist < PINCH_THRESHOLD * 0.82;
+
+        if (pinchHoldFrames >= 3 && (isStrongPinch || now - lastScrollAt > 360)) {
+            window.scrollBy({ top: 130, behavior: 'smooth' });
+            lastScrollAt = now;
+            pinchHoldFrames = 1;
+        }
+    }
 
     // --- Physics loop (always running, acts only on flying words) ---
     function physicsLoop() {
@@ -465,6 +508,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (!results.multiHandLandmarks || results.multiHandLandmarks.length === 0) {
             if (isPinching) { isPinching = false; releaseWord(); }
+            pinchHoldFrames = 0;
+            updateScrollZoneUI(false);
             return;
         }
 
@@ -486,6 +531,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const sy    = midNY       * window.innerHeight;
 
         drawPinchIndicator(sx, sy, pinchNow, dist);
+        handleGestureScroll(sx, sy, pinchNow, dist);
 
         if (pinchNow && !isPinching) {
             // Pinch start
@@ -593,7 +639,7 @@ document.addEventListener('DOMContentLoaded', () => {
         try { await handsInstance.send({ image: video }); } catch (_) {}
 
         mediapipeReady = true;
-        setStatus('✋ 엄지+검지로 별명을 집어 던지세요!');
+        setStatus('✋ 집기/던지기 + 우하단 SCROLL ZONE에서 스크롤');
 
         // Frame processing loop
         async function processFrame() {
@@ -623,11 +669,12 @@ document.addEventListener('DOMContentLoaded', () => {
             handCanvas.style.display = 'block';
             video.style.display      = 'block';
             statusEl.style.display   = 'block';
+            if (scrollZoneEl) scrollZoneEl.style.display = 'flex';
 
             if (!mediapipeReady) {
                 await initHandTracking();
             } else {
-                setStatus('✋ 엄지+검지로 별명을 집어 던지세요!');
+                setStatus('✋ 집기/던지기 + 우하단 SCROLL ZONE에서 스크롤');
                 // Restart frame loop
                 async function processFrame() {
                     if (!gestureActive) return;
@@ -646,6 +693,9 @@ document.addEventListener('DOMContentLoaded', () => {
             handCanvas.style.display = 'none';
             video.style.display      = 'none';
             statusEl.style.display   = 'none';
+            if (scrollZoneEl) scrollZoneEl.style.display = 'none';
+            pinchHoldFrames = 0;
+            updateScrollZoneUI(false);
 
             hCtx.clearRect(0, 0, handCanvas.width, handCanvas.height);
             if (isPinching) { isPinching = false; releaseWord(); }

--- a/styles.css
+++ b/styles.css
@@ -958,46 +958,52 @@ ul {
 }
 
 
-/* ===== Instagram Section ===== */
-.instagram-section {
+/* ===== Merch Section ===== */
+.merch-section {
     background: linear-gradient(160deg, rgba(12, 12, 28, 1) 0%, rgba(18, 8, 32, 1) 100%);
 }
 
-.instagram-grid {
+.merch-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.4rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.2rem;
 }
 
-.instagram-card {
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 16px;
-    overflow: hidden;
-    padding: 0.8rem;
-    backdrop-filter: blur(8px);
-}
-
-.instagram-card .instagram-media {
-    width: 100% !important;
-    min-width: 0 !important;
-    margin: 0 !important;
-    border-radius: 12px !important;
-    background: #fff;
-}
-
-.insta-link {
-    display: inline-flex;
-    margin-top: 0.65rem;
-    color: var(--rb-yellow);
-    font-size: 0.82rem;
-    font-weight: 700;
+.merch-card {
+    display: block;
     text-decoration: none;
-    border-bottom: 1px solid transparent;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    padding: 1rem;
+    min-height: 170px;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.insta-link:hover {
-    border-bottom-color: var(--rb-yellow);
+.merch-card h3 {
+    color: var(--text-primary);
+    font-size: 1rem;
+    margin-bottom: 0.55rem;
+}
+
+.merch-card p {
+    color: rgba(255, 255, 255, 0.66);
+    font-size: 0.84rem;
+    line-height: 1.45;
+}
+
+.merch-card span {
+    display: inline-block;
+    margin-top: 0.9rem;
+    color: var(--rb-yellow);
+    font-weight: 700;
+    font-size: 0.82rem;
+}
+
+.merch-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--rb-red);
+    box-shadow: 0 10px 24px rgba(225, 6, 0, 0.25);
 }
 
 /* ===== Nicknames Word Cloud ===== */

--- a/styles.css
+++ b/styles.css
@@ -958,18 +958,18 @@ ul {
 }
 
 
-/* ===== Videos Section ===== */
-.videos-section {
+/* ===== Instagram Section ===== */
+.instagram-section {
     background: linear-gradient(160deg, rgba(12, 12, 28, 1) 0%, rgba(18, 8, 32, 1) 100%);
 }
 
-.videos-grid {
+.instagram-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 1.4rem;
 }
 
-.video-card {
+.instagram-card {
     background: rgba(255, 255, 255, 0.03);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 16px;
@@ -978,41 +978,17 @@ ul {
     backdrop-filter: blur(8px);
 }
 
-.video-frame {
-    position: relative;
-    width: 100%;
-    padding-bottom: 56.25%;
-    border-radius: 12px;
-    overflow: hidden;
-    background: #000;
+.instagram-card .instagram-media {
+    width: 100% !important;
+    min-width: 0 !important;
+    margin: 0 !important;
+    border-radius: 12px !important;
+    background: #fff;
 }
 
-.video-frame iframe {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    border: 0;
-}
-
-.video-card h3 {
-    margin-top: 0.85rem;
-    font-size: 0.95rem;
-    color: var(--text-primary);
-    letter-spacing: 0.2px;
-}
-
-
-.video-note {
-    margin-top: 0.45rem;
-    color: rgba(255, 255, 255, 0.6);
-    font-size: 0.78rem;
-    line-height: 1.4;
-}
-
-.video-link {
+.insta-link {
     display: inline-flex;
-    margin-top: 0.6rem;
+    margin-top: 0.65rem;
     color: var(--rb-yellow);
     font-size: 0.82rem;
     font-weight: 700;
@@ -1020,7 +996,7 @@ ul {
     border-bottom: 1px solid transparent;
 }
 
-.video-link:hover {
+.insta-link:hover {
     border-bottom-color: var(--rb-yellow);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1133,6 +1133,36 @@ ul {
     50%       { box-shadow: 0 4px 36px rgba(255, 215, 0, 0.75); }
 }
 
+
+#gesture-scroll-zone {
+    position: fixed;
+    right: 16px;
+    bottom: 140px;
+    width: 128px;
+    height: 128px;
+    border-radius: 22px;
+    border: 2px dashed rgba(255, 215, 0, 0.6);
+    background: rgba(10, 10, 26, 0.45);
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 1px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    z-index: 9140;
+    pointer-events: none;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+#gesture-scroll-zone.active {
+    background: rgba(225, 6, 0, 0.32);
+    border-color: var(--rb-red);
+    color: #fff;
+    box-shadow: 0 0 28px rgba(225, 6, 0, 0.52);
+}
+
 /* Status hint shown under the toggle */
 #gesture-status {
     position: fixed;

--- a/styles.css
+++ b/styles.css
@@ -1002,6 +1002,28 @@ ul {
     letter-spacing: 0.2px;
 }
 
+
+.video-note {
+    margin-top: 0.45rem;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.78rem;
+    line-height: 1.4;
+}
+
+.video-link {
+    display: inline-flex;
+    margin-top: 0.6rem;
+    color: var(--rb-yellow);
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+}
+
+.video-link:hover {
+    border-bottom-color: var(--rb-yellow);
+}
+
 /* ===== Nicknames Word Cloud ===== */
 @keyframes wc-float {
     0%, 100% {

--- a/styles.css
+++ b/styles.css
@@ -957,6 +957,51 @@ ul {
     cursor: none !important;
 }
 
+
+/* ===== Videos Section ===== */
+.videos-section {
+    background: linear-gradient(160deg, rgba(12, 12, 28, 1) 0%, rgba(18, 8, 32, 1) 100%);
+}
+
+.videos-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.4rem;
+}
+
+.video-card {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    overflow: hidden;
+    padding: 0.8rem;
+    backdrop-filter: blur(8px);
+}
+
+.video-frame {
+    position: relative;
+    width: 100%;
+    padding-bottom: 56.25%;
+    border-radius: 12px;
+    overflow: hidden;
+    background: #000;
+}
+
+.video-frame iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+.video-card h3 {
+    margin-top: 0.85rem;
+    font-size: 0.95rem;
+    color: var(--text-primary);
+    letter-spacing: 0.2px;
+}
+
 /* ===== Nicknames Word Cloud ===== */
 @keyframes wc-float {
     0%, 100% {
@@ -1133,35 +1178,6 @@ ul {
     50%       { box-shadow: 0 4px 36px rgba(255, 215, 0, 0.75); }
 }
 
-
-#gesture-scroll-zone {
-    position: fixed;
-    right: 16px;
-    bottom: 140px;
-    width: 128px;
-    height: 128px;
-    border-radius: 22px;
-    border: 2px dashed rgba(255, 215, 0, 0.6);
-    background: rgba(10, 10, 26, 0.45);
-    color: rgba(255, 255, 255, 0.72);
-    font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 1px;
-    display: none;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    z-index: 9140;
-    pointer-events: none;
-    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
-}
-
-#gesture-scroll-zone.active {
-    background: rgba(225, 6, 0, 0.32);
-    border-color: var(--rb-red);
-    color: #fff;
-    box-shadow: 0 0 28px rgba(225, 6, 0, 0.52);
-}
 
 /* Status hint shown under the toggle */
 #gesture-status {


### PR DESCRIPTION
### Motivation
- Provide a simple, discoverable way to use the existing webcam hand-gesture controls to scroll the page without a touchscreen by offering a dedicated target zone in the UI.
- Avoid changing existing grab/throw nickname interactions while enabling a complementary pinch-in-zone -> scroll behaviour.

### Description
- Added a fixed `#gesture-scroll-zone` element to `index.html` that appears next to the gesture controls as a visual target for scroll gestures.
- Added styles in `styles.css` to render the zone, including a dashed outline, inactive/active visuals, and an `active` highlight state.
- Extended `script.js` with state and helpers (`pinchHoldFrames`, `lastScrollAt`, `updateScrollZoneUI`, `pointInScrollZone`, `handleGestureScroll`) and integrated `handleGestureScroll` into the MediaPipe results flow to scroll via `window.scrollBy` when a pinch is held inside the zone with simple throttling.
- Updated gesture toggle visibility and status text so the scroll zone shows/hides with gesture mode and the user gets a clear hint about the combined interaction.

### Testing
- Ran `node --check script.js` to validate syntax and it succeeded.
- Served the site locally and captured a Playwright screenshot with gesture mode enabled to verify the scroll zone overlay appears, which succeeded and produced an artifact image.
- Verified the script runs (basic smoke test) and that enabling/disabling gesture mode shows/hides the scroll zone and resets internal scroll state, with no runtime syntax errors observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a6189378832da2a0d49bc17dc7e7)